### PR TITLE
fix: запускать Playwright-скрипты как модули в CI

### DIFF
--- a/.github/workflows/google-serp.yml
+++ b/.github/workflows/google-serp.yml
@@ -103,9 +103,9 @@ jobs:
       
           if [ "$MODE" = "demo" ]; then
             # -u включает небуферизованный вывод Python (ещё меньше шансов "замолчать")
-            xvfb-run -a python -u ./scripts/demo_playwright.py
+            xvfb-run -a python -u -m scripts.demo_playwright
           else
-            xvfb-run -a python -u ./scripts/google_serp_playwright.py
+            xvfb-run -a python -u -m scripts.google_serp_playwright
           fi
       # <<< КОНЕЦ ВСТАВКИ №2 >>>
 


### PR DESCRIPTION
## Цель
- исключить `ModuleNotFoundError` при запуске Python-скриптов в workflow

## Изменения
- перевёл шаги `demo` и `google` на модульный запуск `python -m`

## Влияние на сеть и производительность
- без изменений, команды и аргументы Playwright сохраняются

## Тестирование
- MODE=demo python -u -m scripts.demo_playwright *(падает из-за отсутствия системных зависимостей Playwright, импорт модулей проходит успешно)*

------
https://chatgpt.com/codex/tasks/task_e_68ce859c1be4832d8997f58671c7ddf9